### PR TITLE
Fix print undefined class

### DIFF
--- a/lib/okuribito.rb
+++ b/lib/okuribito.rb
@@ -60,7 +60,7 @@ module Okuribito
       opt ||= @opt
       klass = full_class_name.safe_constantize
       unless klass
-        print_undefined_class(full_class_name)
+        process_undefined_class(full_class_name)
         return
       end
       uniq_constant = full_class_name.gsub(/::/, "Sp")
@@ -111,8 +111,8 @@ module Okuribito
       end
     end
 
-    def print_undefined_class(full_class_name)
-      puts "Undefined class: #{full_class_name}"
+    def process_undefined_class(_full_class_name)
+      # do nothing....
     end
   end
 end

--- a/spec/okuribito_spec.rb
+++ b/spec/okuribito_spec.rb
@@ -223,7 +223,6 @@ describe Okuribito do
           it { is_expected.to eq "TestTarget#deprecated_method" }
         end
       end
-
     end
 
     describe "#patch_okuribito" do

--- a/spec/okuribito_spec.rb
+++ b/spec/okuribito_spec.rb
@@ -237,7 +237,7 @@ describe Okuribito do
         subject { @okuribito.send(:patch_okuribito, "UndefinedTestClass", ["#deprecated_method"]) }
 
         it do
-          expect(@okuribito).to receive(:print_undefined_class)
+          expect(@okuribito).to receive(:process_undefined_class)
           subject
         end
 

--- a/spec/support/test_target.rb
+++ b/spec/support/test_target.rb
@@ -1,28 +1,22 @@
 # frozen_string_literal: true
 class TestTarget
-  def self.deprecated_self_method
-  end
+  def self.deprecated_self_method; end
 
-  def deprecated_method
-  end
+  def deprecated_method; end
 
-  def deprecated_method?
-  end
+  def deprecated_method?; end
 
-  def deprecated_method!
-  end
+  def deprecated_method!; end
 end
 
 module TestModule
   module NestedTestModule
     class TestTarget
-      def deprecated_method
-      end
+      def deprecated_method; end
     end
   end
 
   class TestTarget
-    def deprecated_method
-    end
+    def deprecated_method; end
   end
 end


### PR DESCRIPTION
Okuribito should not affect existing implementations.
So,  I fixed `print_undefined_class` to do nothing.

(It may be better to be able to freely define the behavior when doing unexpected actions.)